### PR TITLE
fix: types not emitted due to incorrect path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ module.exports = class FederatedTypesPlugin {
 
       // TODO: Resolve the file ext automatically if not provided in the ModuleFederation Config
       if ([".ts", ".tsx"].includes(ext)) {
-        const normalizedPath = path.resolve(__dirname, componentFilePath);
+        const normalizedPath = path.resolve(process.cwd(), componentFilePath);
 
         normalizedFileNames.push(normalizedPath);
       } else {


### PR DESCRIPTION
Currently when using this plugin, the `__types_index.json` will contain an empty array `[]`.

This is because the normalized path is pointing to `/node_modules/@module-federation/typescript/src/...` which is incorrect.

I've supplied the current working directory instead to ensure the path is relative to the webpack configuration.