### PR TITLE
feat: split definition files by remote name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,15 +91,15 @@ module.exports = class FederatedTypesPlugin {
 
     remoteUrls.forEach(({ origin, remote }) => {
       axios
-        .get(`${remote}/${this.typescriptFolderName}/${this.typesIndexJsonFileName}`)
-        .then((indexFileResp) => {
+        .get(`${origin}/${this.typescriptFolderName}/${this.typesIndexJsonFileName}`)
+        .then(indexFileResp => {
           // Download all the d.ts files mentioned in the index file
-          indexFileResp.data?.forEach((file) => download(
-            `${remote}/${this.typescriptFolderName}/${file}`,
+          indexFileResp.data?.forEach(file => download(
+            `${origin}/${this.typescriptFolderName}/${file}`,
             `${this.typescriptFolderName}/${remote}`
           ));
         })
-        .catch((e) => console.log("ERROR fetching/writing types", e));
+        .catch(e => console.log("ERROR fetching/writing types", e));
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ module.exports = class FederatedTypesPlugin {
           // Download all the d.ts files mentioned in the index file
           indexFileResp.data?.forEach(file => download(
             `${origin}/${this.typescriptFolderName}/${file}`,
-            path.join(`${this.typescriptFolderName}/${remote}`.replace(/\/undefined/g, '')
+            path.join(`${this.typescriptFolderName}/${remote}`.replace(/\/undefined/g, ''))
           ));
         })
         .catch(e => console.log("ERROR fetching/writing types", e));

--- a/src/index.js
+++ b/src/index.js
@@ -72,20 +72,14 @@ module.exports = class FederatedTypesPlugin {
   }
 
   importRemoteTypes() {
-    const remoteUrls = Object.values(this.remoteComponents).map(r => {
-      const [ remote, url ] = r.split('@');
+    const remoteUrls = Object.entries(remoteComponents).map(([ remote, entry ]) => {
+    const [, url ] = entry.split('@');
 
-      if (!url) {
-        return {
-          origin: new URL(remote).origin
-        };
-      }
-
-      return {
-        origin: new URL(url).origin,
-        remote
-      };
-    });
+    return {
+      origin: new URL(url ?? entry).origin,
+      remote
+    };
+  })
 
     remoteUrls.forEach(({ origin, remote }) => {
       axios
@@ -94,7 +88,7 @@ module.exports = class FederatedTypesPlugin {
           // Download all the d.ts files mentioned in the index file
           indexFileResp.data?.forEach(file => download(
             `${origin}/${this.typescriptFolderName}/${file}`,
-            path.join(`${this.typescriptFolderName}/${remote}`.replace(/\/undefined/g, ''))
+            `${this.typescriptFolderName}/${remote}`
           ));
         })
         .catch(e => console.log("ERROR fetching/writing types", e));

--- a/src/index.js
+++ b/src/index.js
@@ -72,30 +72,32 @@ module.exports = class FederatedTypesPlugin {
   }
 
   importRemoteTypes() {
-    const remoteUrls = Object.values(this.remoteComponents).map((r) => {
+    const remoteUrls = Object.values(this.remoteComponents).map(r => {
+      let remote;
       let url;
-
-      if (r.includes("@")) {
-        url = r.split("@")[1];
+    
+      if (r.includes('@')) {
+        remote = r.split('@')[0];
+        url = r.split('@')[1];
       }
-
+    
       const resolvedURL = new URL(url);
-      return resolvedURL.origin;
+    
+      return { 
+        origin: resolvedURL.origin,
+        remote
+      };
     });
 
-    remoteUrls.forEach((remote) => {
+    remoteUrls.forEach(({ origin, remote }) => {
       axios
-        .get(
-          `${remote}/${this.typescriptFolderName}/${this.typesIndexJsonFileName}`
-        )
+        .get(`${remote}/${this.typescriptFolderName}/${this.typesIndexJsonFileName}`)
         .then((indexFileResp) => {
           // Download all the d.ts files mentioned in the index file
-          indexFileResp.data?.forEach((file) =>
-            download(
-              `${remote}/${this.typescriptFolderName}/${file}`,
-              this.typescriptFolderName
-            )
-          );
+          indexFileResp.data?.forEach((file) => download(
+            `${remote}/${this.typescriptFolderName}/${file}`,
+            `${this.typescriptFolderName}/${remote}`
+          ));
         })
         .catch((e) => console.log("ERROR fetching/writing types", e));
     });

--- a/src/index.js
+++ b/src/index.js
@@ -73,18 +73,16 @@ module.exports = class FederatedTypesPlugin {
 
   importRemoteTypes() {
     const remoteUrls = Object.values(this.remoteComponents).map(r => {
-      let remote;
-      let url;
-    
-      if (r.includes('@')) {
-        remote = r.split('@')[0];
-        url = r.split('@')[1];
+      const [ remote, url ] = r.split('@');
+
+      if (!url) {
+        return {
+          origin: new URL(remote).origin
+        };
       }
-    
-      const resolvedURL = new URL(url);
-    
-      return { 
-        origin: resolvedURL.origin,
+
+      return {
+        origin: new URL(url).origin,
         remote
       };
     });
@@ -96,7 +94,7 @@ module.exports = class FederatedTypesPlugin {
           // Download all the d.ts files mentioned in the index file
           indexFileResp.data?.forEach(file => download(
             `${origin}/${this.typescriptFolderName}/${file}`,
-            `${this.typescriptFolderName}/${remote}`
+            path.join(`${this.typescriptFolderName}/${remote}`.replace(/\/undefined/g, '')
           ));
         })
         .catch(e => console.log("ERROR fetching/writing types", e));


### PR DESCRIPTION
In the event that two or more remotes expose a component with the same name, the consuming application will have an error as it will attempt to merge those definitions into a single file.

This PR will place each definition under the path `@mf-typescript/[remote-name]/[Component].d.ts`