### PR TITLE
Preserve @mf-typescript directories on import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,10 +86,14 @@ module.exports = class FederatedTypesPlugin {
         .get(`${origin}/${this.typescriptFolderName}/${this.typesIndexJsonFileName}`)
         .then(indexFileResp => {
           // Download all the d.ts files mentioned in the index file
-          indexFileResp.data?.forEach(file => download(
-            `${origin}/${this.typescriptFolderName}/${file}`,
-            `${this.typescriptFolderName}/${remote}`
-          ));
+          indexFileResp.data?.forEach(filePath => {
+            const fileTree = filePath.split("/")
+            fileTree.pop()
+            const fileDestDir = fileTree.join("/");
+            download(
+            `${origin}/${this.typescriptFolderName}/${filePath}`,
+            `${this.typescriptFolderName}/${remote}/${fileDestDir}`,
+          )});
         })
         .catch(e => console.log("ERROR fetching/writing types", e));
     });


### PR DESCRIPTION
**Issue**
Given I have these files
```
lib/
├─ state/
│  ├─ counter.ts
├─ Counter.tsx
├─ Header.tsx
```
The generated `@mf-typescript` folder would be
```
@mf-typescript/
├─ state/
│  ├─ counter.d.ts
├─ __types_index.json
├─ Counter.d.ts
├─ Header.d.ts
```

When importing into another app we are downloading the files all into the `@mf-typescript/${remote}` directory with a flat structure. The issue with this is that the `download` package is not case sensitive so with the above example `state/counter.d.ts` and `Counter.d.ts` get merged when being imported.

e.g.
```
@mf-typescript/
├─ [remote]/
│  ├─ counter.d.ts
│  ├─ Header.d.ts
```

**Solution**
Infer the import directory from the file name from `__types_index.json`: We get `state/` from `state/counter.d.ts`.
And the new resulting import structure is as follows
```
@mf-typescript/
├─ state/
│  ├─ counter.d.ts
├─ Counter.d.ts
├─ Header.d.ts
```

~~I've also found that with this new structure I can set `paths` in tsconfig and it will automatically pick up the types for the federated modules~~ only works if the expose structure matches the real source directory structure
```
{
  "compilerOptions": {
		...
    "paths": {
      "*": ["./@mf-typescript/*"]
      }
  }
}
```