### PR TITLE
remove remote types folder when fetching new types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,11 @@ module.exports = class FederatedTypesPlugin {
       axios
         .get(`${origin}/${this.typescriptFolderName}/${this.typesIndexJsonFileName}`)
         .then(indexFileResp => {
+          // remove old remote types directory
+          const remoteTypesDir = path.join(this.typescriptFolderName, remote);
+          if (fs.existsSync(remoteTypesDir)) {
+            fs.rmdirSync(remoteTypesDir, { recursive: true });
+          }
           // Download all the d.ts files mentioned in the index file
           indexFileResp.data?.forEach(file => download(
             `${origin}/${this.typescriptFolderName}/${file}`,


### PR DESCRIPTION
the problem is that when components are not exposed from the remote anymore, and when the plugin fetches up to date types from the remote, it is not removing the old types from the target directory. this could give a false impression of what is being exposed from the remote. This PR remove the target types directory before creating a new one. 